### PR TITLE
Added biomart attributes to rowData of rnaSeq object

### DIFF
--- a/R/AnnotateData.R
+++ b/R/AnnotateData.R
@@ -37,8 +37,11 @@ attributes <- c("ensembl_gene_id",
 
 annot <- getBM(mart = ensembl, attributes = attributes)
 annot <- annot[!duplicated(annot$ensembl_gene_id), ]
-  row.names(annot) <- annot$ensembl_gene_id
+row.names(annot) <- annot$ensembl_gene_id
+inter <- intersect(rnaSeq@NAMES, annot$ensembl_gene_id)
+rnaSeq <- rnaSeq[inter,]
+annot <- annot[inter,]
 annotData <- merge(annot, rowData(rnaSeq), by = "row.names")
+rownames(annotData) <- annotData$ensembl_gene_id
 rowData(rnaSeq) <- annotData
-
 


### PR DESCRIPTION
Some genes in rnaSeq object don't match with biomart. From 60488 features we left 56578. 